### PR TITLE
fix: game state is reset when pushing a new SoloGame view

### DIFF
--- a/Shared/SoloGame.swift
+++ b/Shared/SoloGame.swift
@@ -2,10 +2,9 @@ import Cards
 import SwiftUI
 
 struct SoloGame: View {
-    @State private var game: Game? = .sevens(.init(players: 4))
     let playerIndex: Int = 0
-    
     @State var winner: Int? = nil
+    @State private var game: Game?
 
     var body: some View {
         GameView(game: $game,
@@ -29,6 +28,8 @@ struct SoloGame: View {
                     self.game = .sevens(.init(players: 4))
                 }
             }
+        }.onAppear {
+            game = .sevens(.init(players: 4))
         }
     }
 }


### PR DESCRIPTION
Added a fix to ensure that the game state is reset when exiting a solo game.

https://github.com/Oliver-Binns/Cards/assets/5354593/376a5b05-8686-40bb-897c-86118ceffd3c

